### PR TITLE
FunnAI-Lympics by @KevLoui

### DIFF
--- a/store-apps.json
+++ b/store-apps.json
@@ -9,6 +9,16 @@
             "creator_openchat": "@aespieux",
             "creator_x": "@Akustyl",
             "featured": true
+        },
+        {
+            "name": "FunnAI-Lympics",
+            "url": "https://funnai-mpt-kbz.caffeine.xyz/",
+            "description": "FunnAI challenge tracker, recent winner tracker and mAIner performance tracker with olympic medal style leaderboards. Built using CaffeineAI and on-chain data.",
+            "thumbnail": "",
+            "logo": "",
+            "creator_openchat": "@kevloui",
+            "creator_x": "@MajesticLoui",
+            "featured": true
         }
     ]
 

--- a/store-apps.json
+++ b/store-apps.json
@@ -14,8 +14,8 @@
             "name": "FunnAI-Lympics",
             "url": "https://funnai-mpt-kbz.caffeine.xyz/",
             "description": "FunnAI challenge tracker, recent winner tracker and mAIner performance tracker with olympic medal style leaderboards. Built using CaffeineAI and on-chain data.",
-            "thumbnail": "",
-            "logo": "",
+            "thumbnail": "https://drive.google.com/file/d/1oX8cvs9NMiVKLI7cdRuy2n2wK7KOW-_w/view?usp=sharing",
+            "logo": "https://drive.google.com/file/d/1NToArFXsQNq9PVT1nKWxxRXUU-mz2_Fw/view?usp=sharing",
             "creator_openchat": "@kevloui",
             "creator_x": "@MajesticLoui",
             "featured": true


### PR DESCRIPTION
FunnAI-Lympics is an application built using CaffeineAI to extend the visualisation of data from the FunnAI mAIning protocol by onicai. It uses the canister r5m5y-diaaa-aaaaa-qanaa-cai retrieve recent protocol activity and display them within the dashboard. The current challenges, the recent 20 challenge results and leaderboards (split into hourly, daily and weekly) can be viewed. The backend stores new results in stable memory and produces rolling time periods for the leaderboards.

<img width="1566" height="944" alt="Screenshot 2025-08-05 093819" src="https://github.com/user-attachments/assets/9ace9ec6-fd11-4a08-9ae1-d5707d10975f" />
<img width="1588" height="984" alt="Screenshot 2025-08-05 093841" src="https://github.com/user-attachments/assets/22abb6bf-8f19-49fe-8062-194f4b8eba8e" />
<img width="1380" height="963" alt="Screenshot 2025-08-05 140813" src="https://github.com/user-attachments/assets/982d50d0-ace6-49f2-a346-d6cc139f72dc" />

